### PR TITLE
Bump spring boot from 3.3.5 to 3.3.6 and simplify pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version>
+    <version>3.3.6</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>com.example.tpchuang</groupId>
@@ -29,59 +29,50 @@
   </scm>
   <properties>
     <java.version>21</java.version>
-    <spring.boot.version>3.3.5</spring.boot.version>
-    <!-- jackson version of spring-boot-starter-json:3.3.5 -->
-    <jackson.version>2.17.2</jackson.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-hateoas</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-rest-hal-explorer</artifactId>
-      <!-- auto picked if version not specified -->
-      <version>4.3.5</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
-      <version>${spring.boot.version}</version>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.2.224</version>
+      <!-- use spring-boot-dependencies version -->
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.34</version>
+      <!-- use spring-boot-dependencies version -->
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -92,29 +83,26 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-bom.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-bom.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring.boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-testcontainers</artifactId>
-      <version>${spring.boot.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.19.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request includes several changes to the `pom.xml` file to update dependencies and simplify version management. The most important changes are the version updates for Spring Boot and Jackson dependencies, and the removal of specific version tags for dependencies that will now use the versions defined in `spring-boot-dependencies`.

Dependency updates and simplifications:

* Updated Spring Boot version from `3.3.5` to `3.3.6`.
* Removed specific version tags for Spring Boot dependencies, allowing them to use the version defined in `spring-boot-dependencies`.
* Removed specific version tags for Jackson dependencies, replacing them with `${jackson-bom.version}`.
* Added `<scope>runtime</scope>` and `<optional>true</optional>` tags for `spring-data-rest-hal-explorer` dependency.
* Removed specific version tags for `h2`, `lombok`, and `junit-jupiter` dependencies, allowing them to use the versions defined in `spring-boot-dependencies`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L32-R75) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L95-L117)